### PR TITLE
Feature atomic types

### DIFF
--- a/ballista/rust/executor/Cargo.toml
+++ b/ballista/rust/executor/Cargo.toml
@@ -40,6 +40,7 @@ async-trait = "0.1.41"
 ballista-core = { path = "../core", version = "0.8.0" }
 chrono = { version = "0.4", default-features = false }
 configure_me = "0.4.0"
+dashmap = "5.4.0"
 datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "06a4f79f02fcb6ea85303925b7c5a9b0231e3fee" }
 datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "06a4f79f02fcb6ea85303925b7c5a9b0231e3fee" }
 futures = "0.3"

--- a/ballista/rust/executor/src/executor_server.rs
+++ b/ballista/rust/executor/src/executor_server.rs
@@ -21,7 +21,7 @@ use std::convert::TryInto;
 use std::ops::Deref;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use tokio::sync::{mpsc, RwLock};
+use tokio::sync::mpsc;
 
 use log::{debug, error, info, warn};
 use tonic::transport::Channel;
@@ -44,6 +44,7 @@ use ballista_core::serde::{AsExecutionPlan, BallistaCodec};
 use ballista_core::utils::{
     collect_plan_metrics, create_grpc_client_connection, create_grpc_server,
 };
+use dashmap::DashMap;
 use datafusion::execution::context::TaskContext;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion_proto::logical_plan::AsLogicalPlan;
@@ -56,7 +57,7 @@ use crate::executor::Executor;
 use crate::shutdown::ShutdownNotifier;
 
 type ServerHandle = JoinHandle<Result<(), BallistaError>>;
-type SchedulerClients = Arc<RwLock<HashMap<String, SchedulerGrpcClient<Channel>>>>;
+type SchedulerClients = Arc<DashMap<String, SchedulerGrpcClient<Channel>>>;
 
 /// Wrap TaskDefinition with its curator scheduler id for task update to its specific curator scheduler later
 #[derive(Debug)]
@@ -215,10 +216,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> ExecutorServer<T,
         &self,
         scheduler_id: &str,
     ) -> Result<SchedulerGrpcClient<Channel>, BallistaError> {
-        let scheduler = {
-            let schedulers = self.schedulers.read().await;
-            schedulers.get(scheduler_id).cloned()
-        };
+        let scheduler = self.schedulers.get(scheduler_id).map(|value| value.clone());
         // If channel does not exist, create a new one
         if let Some(scheduler) = scheduler {
             Ok(scheduler)
@@ -228,8 +226,8 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> ExecutorServer<T,
             let scheduler = SchedulerGrpcClient::new(connection);
 
             {
-                let mut schedulers = self.schedulers.write().await;
-                schedulers.insert(scheduler_id.to_owned(), scheduler.clone());
+                self.schedulers
+                    .insert(scheduler_id.to_owned(), scheduler.clone());
             }
 
             Ok(scheduler)
@@ -262,8 +260,10 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> ExecutorServer<T,
             }
         };
 
-        let schedulers = self.schedulers.read().await.clone();
-        for (scheduler_id, mut scheduler) in schedulers {
+        for mut item in self.schedulers.iter_mut() {
+            let scheduler_id = item.key().clone();
+            let scheduler = item.value_mut();
+
             match scheduler
                 .heart_beat_from_executor(heartbeat_params.clone())
                 .await

--- a/ballista/rust/scheduler/Cargo.toml
+++ b/ballista/rust/scheduler/Cargo.toml
@@ -45,6 +45,7 @@ ballista-core = { path = "../core", version = "0.8.0" }
 base64 = { version = "0.13", default-features = false }
 clap = { version = "3", features = ["derive", "cargo"] }
 configure_me = "0.4.0"
+dashmap = "5.4.0"
 datafusion = { git = "https://github.com/apache/arrow-datafusion", rev = "06a4f79f02fcb6ea85303925b7c5a9b0231e3fee" }
 datafusion-proto = { git = "https://github.com/apache/arrow-datafusion", rev = "06a4f79f02fcb6ea85303925b7c5a9b0231e3fee" }
 etcd-client = { version = "0.9", optional = true }

--- a/ballista/rust/scheduler/src/state/backend/etcd.rs
+++ b/ballista/rust/scheduler/src/state/backend/etcd.rs
@@ -163,19 +163,11 @@ impl StateBackendClient for EtcdClient {
             .await
             .map_err(|e| {
                 error!("etcd operation failed: {}", e);
-                ballista_error("etcd transaction failed")
+                ballista_error(&*format!("etcd operation failed: {}", e))
             })
             .map(|_| ())
     }
 
-    async fn locks(&self, mut ids: Vec<(Keyspace, &str)>) -> Result<Vec<Box<dyn Lock>>> {
-        ids.sort_by_key(|n| format!("/{}/{:?}/{}", self.namespace, n.0, n.1));
-        let mut res = vec![];
-        for (keyspace, key) in ids {
-            res.push(self.lock(keyspace, key).await?)
-        }
-        Ok(res)
-    }
     async fn mv(
         &self,
         from_keyspace: Keyspace,
@@ -209,6 +201,7 @@ impl StateBackendClient for EtcdClient {
 
         Ok(())
     }
+
     async fn lock(&self, keyspace: Keyspace, key: &str) -> Result<Box<dyn Lock>> {
         let start = Instant::now();
         let mut etcd = self.etcd.clone();

--- a/ballista/rust/scheduler/src/state/backend/etcd.rs
+++ b/ballista/rust/scheduler/src/state/backend/etcd.rs
@@ -144,37 +144,28 @@ impl StateBackendClient for EtcdClient {
             .map(|_| ())
     }
 
-    /// put_txn is changed into apply_txn, since we may want
-    async fn apply_txn(
-        &self,
-        ops: Vec<(Operation, Keyspace, String, Option<Vec<u8>>)>,
-    ) -> Result<()> {
+    /// Apply multiple operations in a single transaction.
+    async fn apply_txn(&self, ops: Vec<(Operation, Keyspace, String)>) -> Result<()> {
         let mut etcd = self.etcd.clone();
 
-        let txn_ops: Result<Vec<TxnOp>> = ops
+        let txn_ops: Vec<TxnOp> = ops
             .into_iter()
-            .map(|(operation, ks, key, value)| {
+            .map(|(operation, ks, key)| {
                 let key = format!("/{}/{:?}/{}", self.namespace, ks, key);
                 match operation {
-                    Operation::Put => Ok(TxnOp::put(key.as_str(), value.ok_or_else(|| ballista_error("ETCD cannot conduct Put operation. Put operation value cannot be None"))?, None)),
-                    Operation::Delete => Ok(TxnOp::delete(key.as_str(), None)),
+                    Operation::Put(value) => TxnOp::put(key, value, None),
+                    Operation::Delete => TxnOp::delete(key, None),
                 }
             })
-            .collect::<Result<Vec<TxnOp>>>();
+            .collect();
 
-        match txn_ops {
-            Ok(value) => {
-                let txn = Txn::new().and_then(value);
-                etcd.txn(txn)
-                    .await
-                    .map_err(|e| {
-                        error!("etcd operation failed: {}", e);
-                        ballista_error("etcd transaction put failed")
-                    })
-                    .map(|_| ())
-            }
-            Err(e) => Err(e),
-        }
+        etcd.txn(Txn::new().and_then(txn_ops))
+            .await
+            .map_err(|e| {
+                error!("etcd operation failed: {}", e);
+                ballista_error("etcd transaction failed")
+            })
+            .map(|_| ())
     }
 
     async fn locks(&self, mut ids: Vec<(Keyspace, &str)>) -> Result<Vec<Box<dyn Lock>>> {

--- a/ballista/rust/scheduler/src/state/backend/etcd.rs
+++ b/ballista/rust/scheduler/src/state/backend/etcd.rs
@@ -30,7 +30,9 @@ use etcd_client::{
 use futures::{Stream, StreamExt};
 use log::{debug, error, warn};
 
-use crate::state::backend::{Keyspace, Lock, StateBackendClient, Watch, WatchEvent};
+use crate::state::backend::{
+    Keyspace, Lock, Operation, StateBackendClient, Watch, WatchEvent,
+};
 
 /// A [`StateBackendClient`] implementation that uses etcd to save cluster configuration.
 #[derive(Clone)]
@@ -137,33 +139,52 @@ impl StateBackendClient for EtcdClient {
             .await
             .map_err(|e| {
                 warn!("etcd put failed: {}", e);
-                ballista_error("etcd put failed")
+                ballista_error(&*format!("etcd put failed: {}", e))
             })
             .map(|_| ())
     }
 
-    async fn put_txn(&self, ops: Vec<(Keyspace, String, Vec<u8>)>) -> Result<()> {
+    /// put_txn is changed into apply_txn, since we may want
+    async fn apply_txn(
+        &self,
+        ops: Vec<(Operation, Keyspace, String, Option<Vec<u8>>)>,
+    ) -> Result<()> {
         let mut etcd = self.etcd.clone();
 
-        let txn_ops: Vec<TxnOp> = ops
+        let txn_ops: Result<Vec<TxnOp>> = ops
             .into_iter()
-            .map(|(ks, key, value)| {
+            .map(|(operation, ks, key, value)| {
                 let key = format!("/{}/{:?}/{}", self.namespace, ks, key);
-                TxnOp::put(key, value, None)
+                match operation {
+                    Operation::Put => Ok(TxnOp::put(key.as_str(), value.ok_or_else(|| ballista_error("ETCD cannot conduct Put operation. Put operation value cannot be None"))?, None)),
+                    Operation::Delete => Ok(TxnOp::delete(key.as_str(), None)),
+                }
             })
-            .collect();
+            .collect::<Result<Vec<TxnOp>>>();
 
-        let txn = Txn::new().and_then(txn_ops);
-
-        etcd.txn(txn)
-            .await
-            .map_err(|e| {
-                error!("etcd put failed: {}", e);
-                ballista_error("etcd transaction put failed")
-            })
-            .map(|_| ())
+        match txn_ops {
+            Ok(value) => {
+                let txn = Txn::new().and_then(value);
+                etcd.txn(txn)
+                    .await
+                    .map_err(|e| {
+                        error!("etcd operation failed: {}", e);
+                        ballista_error("etcd transaction put failed")
+                    })
+                    .map(|_| ())
+            }
+            Err(e) => Err(e),
+        }
     }
 
+    async fn locks(&self, mut ids: Vec<(Keyspace, &str)>) -> Result<Vec<Box<dyn Lock>>> {
+        ids.sort_by_key(|n| format!("/{}/{:?}/{}", self.namespace, n.0, n.1));
+        let mut res = vec![];
+        for (keyspace, key) in ids {
+            res.push(self.lock(keyspace, key).await?)
+        }
+        Ok(res)
+    }
     async fn mv(
         &self,
         from_keyspace: Keyspace,
@@ -197,7 +218,6 @@ impl StateBackendClient for EtcdClient {
 
         Ok(())
     }
-
     async fn lock(&self, keyspace: Keyspace, key: &str) -> Result<Box<dyn Lock>> {
         let start = Instant::now();
         let mut etcd = self.etcd.clone();

--- a/ballista/rust/scheduler/src/state/backend/mod.rs
+++ b/ballista/rust/scheduler/src/state/backend/mod.rs
@@ -17,7 +17,7 @@
 
 use ballista_core::error::Result;
 use clap::ArgEnum;
-use futures::Stream;
+use futures::{future, Stream};
 use std::collections::HashSet;
 use std::fmt;
 use tokio::sync::OwnedMutexGuard;
@@ -49,7 +49,7 @@ impl parse_arg::ParseArgFromStr for StateBackend {
     }
 }
 
-#[derive(Debug, Eq, PartialEq, Hash, Clone)]
+#[derive(Debug, Eq, PartialEq, Hash)]
 pub enum Keyspace {
     Executors,
     ActiveJobs,
@@ -97,11 +97,19 @@ pub trait StateBackendClient: Send + Sync {
     async fn put(&self, keyspace: Keyspace, key: String, value: Vec<u8>) -> Result<()>;
 
     /// Bundle multiple operation in a single transaction. Either all values should be saved, or all should fail.
-    /// It can support multiple type of operations and keyspace. If the count of the unique keyspace is more than one,
+    /// It can support multiple types of operations and keyspaces. If the count of the unique keyspace is more than one,
     /// more than one locks has to be acquired.
     async fn apply_txn(&self, ops: Vec<(Operation, Keyspace, String)>) -> Result<()>;
     /// Acquire mutex with specified IDs.
-    async fn locks(&self, ids: Vec<(Keyspace, &str)>) -> Result<Vec<Box<dyn Lock>>>;
+    async fn acquire_locks(
+        &self,
+        mut ids: Vec<(Keyspace, &str)>,
+    ) -> Result<Vec<Box<dyn Lock>>> {
+        // We always acquire locks in a specific order to avoid deadlocks.
+        ids.sort_by_key(|n| format!("/{:?}/{}", n.0, n.1));
+        future::try_join_all(ids.into_iter().map(move |(ks, key)| self.lock(ks, key)))
+            .await
+    }
 
     /// Atomically move the given key from one keyspace to another
     async fn mv(

--- a/ballista/rust/scheduler/src/state/backend/mod.rs
+++ b/ballista/rust/scheduler/src/state/backend/mod.rs
@@ -62,7 +62,7 @@ pub enum Keyspace {
 
 #[derive(Debug, Eq, PartialEq, Hash)]
 pub enum Operation {
-    Put,
+    Put(Vec<u8>),
     Delete,
 }
 
@@ -99,10 +99,7 @@ pub trait StateBackendClient: Send + Sync {
     /// Bundle multiple operation in a single transaction. Either all values should be saved, or all should fail.
     /// It can support multiple type of operations and keyspace. If the count of the unique keyspace is more than one,
     /// more than one locks has to be acquired.
-    async fn apply_txn(
-        &self,
-        ops: Vec<(Operation, Keyspace, String, Option<Vec<u8>>)>,
-    ) -> Result<()>;
+    async fn apply_txn(&self, ops: Vec<(Operation, Keyspace, String)>) -> Result<()>;
     /// Acquire mutex with specified IDs.
     async fn locks(&self, ids: Vec<(Keyspace, &str)>) -> Result<Vec<Box<dyn Lock>>>;
 

--- a/ballista/rust/scheduler/src/state/backend/mod.rs
+++ b/ballista/rust/scheduler/src/state/backend/mod.rs
@@ -49,7 +49,7 @@ impl parse_arg::ParseArgFromStr for StateBackend {
     }
 }
 
-#[derive(Debug, Eq, PartialEq, Hash)]
+#[derive(Debug, Eq, PartialEq, Hash, Clone)]
 pub enum Keyspace {
     Executors,
     ActiveJobs,
@@ -58,6 +58,12 @@ pub enum Keyspace {
     Slots,
     Sessions,
     Heartbeats,
+}
+
+#[derive(Debug, Eq, PartialEq, Hash)]
+pub enum Operation {
+    Put,
+    Delete,
 }
 
 /// A trait that contains the necessary methods to save and retrieve the state and configuration of a cluster.
@@ -90,8 +96,15 @@ pub trait StateBackendClient: Send + Sync {
     /// Saves the value into the provided key, overriding any previous data that might have been associated to that key.
     async fn put(&self, keyspace: Keyspace, key: String, value: Vec<u8>) -> Result<()>;
 
-    /// Save multiple values in a single transaction. Either all values should be saved, or all should fail
-    async fn put_txn(&self, ops: Vec<(Keyspace, String, Vec<u8>)>) -> Result<()>;
+    /// Bundle multiple operation in a single transaction. Either all values should be saved, or all should fail.
+    /// It can support multiple type of operations and keyspace. If the count of the unique keyspace is more than one,
+    /// more than one locks has to be acquired.
+    async fn apply_txn(
+        &self,
+        ops: Vec<(Operation, Keyspace, String, Option<Vec<u8>>)>,
+    ) -> Result<()>;
+    /// Acquire mutex with specified IDs.
+    async fn locks(&self, ids: Vec<(Keyspace, &str)>) -> Result<Vec<Box<dyn Lock>>>;
 
     /// Atomically move the given key from one keyspace to another
     async fn mv(

--- a/ballista/rust/scheduler/src/state/backend/standalone.rs
+++ b/ballista/rust/scheduler/src/state/backend/standalone.rs
@@ -180,18 +180,6 @@ impl StateBackendClient for StandaloneClient {
             ballista_error("sled operations failed")
         })
     }
-    /// If a transaction needs to lock multiple keyspace/key combination, [`locks`] can be used.
-    /// Since this may cause a race condition if the lock acquire/release order is not considered,
-    /// we used a stable sort via string format while acquiring the locks and reversed order
-    /// while releasing the locks.
-    async fn locks(&self, mut ids: Vec<(Keyspace, &str)>) -> Result<Vec<Box<dyn Lock>>> {
-        ids.sort_by_key(|n| format!("/{:?}/{}", n.0, n.1));
-        let mut res = vec![];
-        for (keyspace, key) in ids {
-            res.push(self.lock(keyspace, key).await?)
-        }
-        Ok(res)
-    }
 
     async fn mv(
         &self,
@@ -323,7 +311,7 @@ mod tests {
         let key = "key".to_string();
         let value = "value".as_bytes().to_vec();
         let locks = client
-            .locks(vec![(Keyspace::ActiveJobs, ""), (Keyspace::Slots, "")])
+            .acquire_locks(vec![(Keyspace::ActiveJobs, ""), (Keyspace::Slots, "")])
             .await?;
 
         let _r: ballista_core::error::Result<()> = with_locks(locks, async {

--- a/ballista/rust/scheduler/src/state/backend/standalone.rs
+++ b/ballista/rust/scheduler/src/state/backend/standalone.rs
@@ -25,7 +25,9 @@ use log::warn;
 use sled_package as sled;
 use tokio::sync::Mutex;
 
-use crate::state::backend::{Keyspace, Lock, StateBackendClient, Watch, WatchEvent};
+use crate::state::backend::{
+    Keyspace, Lock, Operation, StateBackendClient, Watch, WatchEvent,
+};
 
 /// A [`StateBackendClient`] implementation that uses file-based storage to save cluster configuration.
 #[derive(Clone)]
@@ -162,18 +164,39 @@ impl StateBackendClient for StandaloneClient {
             .map(|_| ())
     }
 
-    async fn put_txn(&self, ops: Vec<(Keyspace, String, Vec<u8>)>) -> Result<()> {
+    async fn apply_txn(
+        &self,
+        ops: Vec<(Operation, Keyspace, String, Option<Vec<u8>>)>,
+    ) -> Result<()> {
         let mut batch = sled::Batch::default();
 
-        for (ks, key, value) in ops {
-            let key = format!("/{:?}/{}", ks, key);
-            batch.insert(key.as_str(), value);
+        for (ks, keyspace, key_str, value) in ops {
+            let key = format!("/{:?}/{}", &keyspace, key_str);
+            match ks {
+                Operation::Put => batch.insert(
+                    key.as_str(),
+                    value.ok_or_else(|| ballista_error("Sled cannot conduct Put operation. Put operation value cannot be None"))?,
+                ),
+                Operation::Delete => batch.remove(key.as_str()),
+            }
         }
 
         self.db.apply_batch(batch).map_err(|e| {
             warn!("sled transaction insert failed: {}", e);
-            ballista_error("sled insert failed")
+            ballista_error("sled operations failed")
         })
+    }
+    /// If a transaction needs to lock multiple keyspace/key combination, [`locks`] can be used.
+    /// Since this may cause a race condition if the lock acquire/release order is not considered,
+    /// we used a stable sort via string format while acquiring the locks and reversed order
+    /// while releasing the locks.
+    async fn locks(&self, mut ids: Vec<(Keyspace, &str)>) -> Result<Vec<Box<dyn Lock>>> {
+        ids.sort_by_key(|n| format!("/{:?}/{}", n.0, n.1));
+        let mut res = vec![];
+        for (keyspace, key) in ids {
+            res.push(self.lock(keyspace, key).await?)
+        }
+        Ok(res)
     }
 
     async fn mv(
@@ -279,7 +302,8 @@ impl Stream for SledWatch {
 mod tests {
     use super::{StandaloneClient, StateBackendClient, Watch, WatchEvent};
 
-    use crate::state::backend::Keyspace;
+    use crate::state::backend::{Keyspace, Operation};
+    use crate::state::with_locks;
     use futures::StreamExt;
     use std::result::Result;
 
@@ -296,6 +320,40 @@ mod tests {
             .put(Keyspace::Slots, key.to_owned(), value.to_vec())
             .await?;
         assert_eq!(client.get(Keyspace::Slots, key).await?, value);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn multiple_operation() -> Result<(), Box<dyn std::error::Error>> {
+        let client = create_instance()?;
+        let key = "key".to_string();
+        let value = "value".as_bytes().to_vec();
+        let locks = client
+            .locks(vec![(Keyspace::ActiveJobs, ""), (Keyspace::Slots, "")])
+            .await?;
+
+        let _r: ballista_core::error::Result<()> = with_locks(locks, async {
+            let txn_ops = vec![
+                (
+                    Operation::Put,
+                    Keyspace::Slots,
+                    key.clone(),
+                    Some(value.clone()),
+                ),
+                (
+                    Operation::Put,
+                    Keyspace::ActiveJobs,
+                    key.clone(),
+                    Some(value.clone()),
+                ),
+            ];
+            client.apply_txn(txn_ops).await?;
+            Ok(())
+        })
+        .await;
+
+        assert_eq!(client.get(Keyspace::Slots, key.as_str()).await?, value);
+        assert_eq!(client.get(Keyspace::ActiveJobs, key.as_str()).await?, value);
         Ok(())
     }
 

--- a/ballista/rust/scheduler/src/state/backend/standalone.rs
+++ b/ballista/rust/scheduler/src/state/backend/standalone.rs
@@ -164,19 +164,13 @@ impl StateBackendClient for StandaloneClient {
             .map(|_| ())
     }
 
-    async fn apply_txn(
-        &self,
-        ops: Vec<(Operation, Keyspace, String, Option<Vec<u8>>)>,
-    ) -> Result<()> {
+    async fn apply_txn(&self, ops: Vec<(Operation, Keyspace, String)>) -> Result<()> {
         let mut batch = sled::Batch::default();
 
-        for (ks, keyspace, key_str, value) in ops {
+        for (op, keyspace, key_str) in ops {
             let key = format!("/{:?}/{}", &keyspace, key_str);
-            match ks {
-                Operation::Put => batch.insert(
-                    key.as_str(),
-                    value.ok_or_else(|| ballista_error("Sled cannot conduct Put operation. Put operation value cannot be None"))?,
-                ),
+            match op {
+                Operation::Put(value) => batch.insert(key.as_str(), value),
                 Operation::Delete => batch.remove(key.as_str()),
             }
         }
@@ -334,17 +328,11 @@ mod tests {
 
         let _r: ballista_core::error::Result<()> = with_locks(locks, async {
             let txn_ops = vec![
+                (Operation::Put(value.clone()), Keyspace::Slots, key.clone()),
                 (
-                    Operation::Put,
-                    Keyspace::Slots,
-                    key.clone(),
-                    Some(value.clone()),
-                ),
-                (
-                    Operation::Put,
+                    Operation::Put(value.clone()),
                     Keyspace::ActiveJobs,
                     key.clone(),
-                    Some(value.clone()),
                 ),
             ];
             client.apply_txn(txn_ops).await?;

--- a/ballista/rust/scheduler/src/state/executor_manager.rs
+++ b/ballista/rust/scheduler/src/state/executor_manager.rs
@@ -130,7 +130,7 @@ impl ExecutorManager {
 
             let alive_executors = self.get_alive_executors_within_one_minute();
 
-            let mut txn_ops: Vec<(Operation, Keyspace, String, Option<Vec<u8>>)> = vec![];
+            let mut txn_ops: Vec<(Operation, Keyspace, String)> = vec![];
 
             for executor_id in alive_executors {
                 let value = self.state.get(Keyspace::Slots, &executor_id).await?;
@@ -146,12 +146,7 @@ impl ExecutorManager {
 
                 let proto: protobuf::ExecutorData = data.into();
                 let new_data = encode_protobuf(&proto)?;
-                txn_ops.push((
-                    Operation::Put,
-                    Keyspace::Slots,
-                    executor_id,
-                    Some(new_data),
-                ));
+                txn_ops.push((Operation::Put(new_data), Keyspace::Slots, executor_id));
 
                 if desired == 0 {
                     break;
@@ -200,22 +195,14 @@ impl ExecutorManager {
                 }
             }
 
-            let txn_ops: Vec<(Operation, Keyspace, String, Option<Vec<u8>>)> =
-                executor_slots
-                    .into_iter()
-                    .map(|(executor_id, data)| {
-                        let proto: protobuf::ExecutorData = data.into();
-                        let new_data = encode_protobuf(&proto)?;
-                        Ok(
-                            (
-                                Operation::Put,
-                                Keyspace::Slots,
-                                executor_id,
-                                Some(new_data),
-                            ),
-                        )
-                    })
-                    .collect::<Result<Vec<_>>>()?;
+            let txn_ops: Vec<(Operation, Keyspace, String)> = executor_slots
+                .into_iter()
+                .map(|(executor_id, data)| {
+                    let proto: protobuf::ExecutorData = data.into();
+                    let new_data = encode_protobuf(&proto)?;
+                    Ok((Operation::Put(new_data), Keyspace::Slots, executor_id))
+                })
+                .collect::<Result<Vec<_>>>()?;
 
             self.state.apply_txn(txn_ops).await?;
 

--- a/ballista/rust/scheduler/src/state/executor_manager.rs
+++ b/ballista/rust/scheduler/src/state/executor_manager.rs
@@ -17,7 +17,7 @@
 
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use crate::state::backend::{Keyspace, StateBackendClient, WatchEvent};
+use crate::state::backend::{Keyspace, Operation, StateBackendClient, WatchEvent};
 
 use crate::state::{decode_into, decode_protobuf, encode_protobuf, with_lock};
 use ballista_core::error::{BallistaError, Result};
@@ -29,14 +29,14 @@ use ballista_core::serde::protobuf::{
 };
 use ballista_core::serde::scheduler::{ExecutorData, ExecutorMetadata};
 use ballista_core::utils::create_grpc_client_connection;
+use dashmap::{DashMap, DashSet};
 use futures::StreamExt;
 use log::{debug, info};
-use parking_lot::RwLock;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use tonic::transport::Channel;
 
-type ExecutorClients = Arc<RwLock<HashMap<String, ExecutorGrpcClient<Channel>>>>;
+type ExecutorClients = Arc<DashMap<String, ExecutorGrpcClient<Channel>>>;
 
 /// Represents a task slot that is reserved (i.e. available for scheduling but not visible to the
 /// rest of the system).
@@ -84,11 +84,11 @@ pub const DEFAULT_EXECUTOR_TIMEOUT_SECONDS: u64 = 180;
 pub(crate) struct ExecutorManager {
     state: Arc<dyn StateBackendClient>,
     // executor_id -> ExecutorMetadata map
-    executor_metadata: Arc<RwLock<HashMap<String, ExecutorMetadata>>>,
+    executor_metadata: Arc<DashMap<String, ExecutorMetadata>>,
     // executor_id -> ExecutorHeartbeat map
-    executors_heartbeat: Arc<RwLock<HashMap<String, protobuf::ExecutorHeartbeat>>>,
+    executors_heartbeat: Arc<DashMap<String, protobuf::ExecutorHeartbeat>>,
     // dead executor sets:
-    dead_executors: Arc<RwLock<HashSet<String>>>,
+    dead_executors: Arc<DashSet<String>>,
     clients: ExecutorClients,
 }
 
@@ -96,9 +96,9 @@ impl ExecutorManager {
     pub(crate) fn new(state: Arc<dyn StateBackendClient>) -> Self {
         Self {
             state,
-            executor_metadata: Arc::new(RwLock::new(HashMap::new())),
-            executors_heartbeat: Arc::new(RwLock::new(HashMap::new())),
-            dead_executors: Arc::new(RwLock::new(HashSet::new())),
+            executor_metadata: Arc::new(DashMap::new()),
+            executors_heartbeat: Arc::new(DashMap::new()),
+            dead_executors: Arc::new(DashSet::new()),
             clients: Default::default(),
         }
     }
@@ -129,7 +129,7 @@ impl ExecutorManager {
 
             let alive_executors = self.get_alive_executors_within_one_minute();
 
-            let mut txn_ops: Vec<(Keyspace, String, Vec<u8>)> = vec![];
+            let mut txn_ops: Vec<(Operation, Keyspace, String, Option<Vec<u8>>)> = vec![];
 
             for executor_id in alive_executors {
                 let value = self.state.get(Keyspace::Slots, &executor_id).await?;
@@ -145,14 +145,19 @@ impl ExecutorManager {
 
                 let proto: protobuf::ExecutorData = data.into();
                 let new_data = encode_protobuf(&proto)?;
-                txn_ops.push((Keyspace::Slots, executor_id, new_data));
+                txn_ops.push((
+                    Operation::Put,
+                    Keyspace::Slots,
+                    executor_id,
+                    Some(new_data),
+                ));
 
                 if desired == 0 {
                     break;
                 }
             }
 
-            self.state.put_txn(txn_ops).await?;
+            self.state.apply_txn(txn_ops).await?;
 
             let elapsed = start.elapsed();
             info!(
@@ -194,16 +199,24 @@ impl ExecutorManager {
                 }
             }
 
-            let txn_ops: Vec<(Keyspace, String, Vec<u8>)> = executor_slots
-                .into_iter()
-                .map(|(executor_id, data)| {
-                    let proto: protobuf::ExecutorData = data.into();
-                    let new_data = encode_protobuf(&proto)?;
-                    Ok((Keyspace::Slots, executor_id, new_data))
-                })
-                .collect::<Result<Vec<_>>>()?;
+            let txn_ops: Vec<(Operation, Keyspace, String, Option<Vec<u8>>)> =
+                executor_slots
+                    .into_iter()
+                    .map(|(executor_id, data)| {
+                        let proto: protobuf::ExecutorData = data.into();
+                        let new_data = encode_protobuf(&proto)?;
+                        Ok(
+                            (
+                                Operation::Put,
+                                Keyspace::Slots,
+                                executor_id,
+                                Some(new_data),
+                            ),
+                        )
+                    })
+                    .collect::<Result<Vec<_>>>()?;
 
-            self.state.put_txn(txn_ops).await?;
+            self.state.apply_txn(txn_ops).await?;
 
             let elapsed = start.elapsed();
             info!(
@@ -220,10 +233,7 @@ impl ExecutorManager {
         &self,
         executor_id: &str,
     ) -> Result<ExecutorGrpcClient<Channel>> {
-        let client = {
-            let clients = self.clients.read();
-            clients.get(executor_id).cloned()
-        };
+        let client = self.clients.get(executor_id).map(|value| value.clone());
 
         if let Some(client) = client {
             Ok(client)
@@ -237,8 +247,7 @@ impl ExecutorManager {
             let client = ExecutorGrpcClient::new(connection);
 
             {
-                let mut clients = self.clients.write();
-                clients.insert(executor_id.to_owned(), client.clone());
+                self.clients.insert(executor_id.to_owned(), client.clone());
             }
             Ok(client)
         }
@@ -247,11 +256,10 @@ impl ExecutorManager {
     /// Get a list of all executors along with the timestamp of their last recorded heartbeat
     pub async fn get_executor_state(&self) -> Result<Vec<(ExecutorMetadata, Duration)>> {
         let heartbeat_timestamps: Vec<(String, u64)> = {
-            let heartbeats = self.executors_heartbeat.read();
-
-            heartbeats
+            self.executors_heartbeat
                 .iter()
-                .map(|(executor_id, heartbeat)| {
+                .map(|item| {
+                    let (executor_id, heartbeat) = item.pair();
                     (executor_id.clone(), heartbeat.timestamp)
                 })
                 .collect()
@@ -274,8 +282,7 @@ impl ExecutorManager {
         executor_id: &str,
     ) -> Result<ExecutorMetadata> {
         {
-            let metadata_cache = self.executor_metadata.read();
-            if let Some(cached) = metadata_cache.get(executor_id) {
+            if let Some(cached) = self.executor_metadata.get(executor_id) {
                 return Ok(cached.clone());
             }
         }
@@ -426,8 +433,8 @@ impl ExecutorManager {
             .put(Keyspace::Heartbeats, executor_id, value)
             .await?;
 
-        let mut executors_heartbeat = self.executors_heartbeat.write();
-        executors_heartbeat.insert(heartbeat.executor_id.clone(), heartbeat);
+        self.executors_heartbeat
+            .insert(heartbeat.executor_id.clone(), heartbeat);
 
         Ok(())
     }
@@ -442,22 +449,19 @@ impl ExecutorManager {
             .put(Keyspace::Heartbeats, executor_id.clone(), value)
             .await?;
 
-        let mut executors_heartbeat = self.executors_heartbeat.write();
-        executors_heartbeat.remove(&heartbeat.executor_id.clone());
-
-        let mut dead_executors = self.dead_executors.write();
-        dead_executors.insert(executor_id);
+        self.executors_heartbeat
+            .remove(&heartbeat.executor_id.clone());
+        self.dead_executors.insert(executor_id);
         Ok(())
     }
 
     pub(crate) fn is_dead_executor(&self, executor_id: &str) -> bool {
-        self.dead_executors.read().contains(executor_id)
+        self.dead_executors.contains(executor_id)
     }
 
     /// Initialize the set of active executor heartbeats from storage
     async fn init_active_executor_heartbeats(&self) -> Result<()> {
         let heartbeats = self.state.scan(Keyspace::Heartbeats, None).await?;
-        let mut cache = self.executors_heartbeat.write();
 
         for (_, value) in heartbeats {
             let data: protobuf::ExecutorHeartbeat = decode_protobuf(&value)?;
@@ -466,7 +470,7 @@ impl ExecutorManager {
                 status: Some(executor_status::Status::Active(_)),
             }) = data.status
             {
-                cache.insert(executor_id, data);
+                self.executors_heartbeat.insert(executor_id, data);
             }
         }
         Ok(())
@@ -478,10 +482,10 @@ impl ExecutorManager {
         &self,
         last_seen_ts_threshold: u64,
     ) -> HashSet<String> {
-        let executors_heartbeat = self.executors_heartbeat.read();
-        executors_heartbeat
+        self.executors_heartbeat
             .iter()
-            .filter_map(|(exec, heartbeat)| {
+            .filter_map(|pair| {
+                let (exec, heartbeat) = pair.pair();
                 (heartbeat.timestamp > last_seen_ts_threshold).then(|| exec.clone())
             })
             .collect()
@@ -497,10 +501,11 @@ impl ExecutorManager {
             .unwrap_or_else(|| Duration::from_secs(0))
             .as_secs();
 
-        let lock = self.executors_heartbeat.read();
-        let expired_executors = lock
+        let expired_executors = self
+            .executors_heartbeat
             .iter()
-            .filter_map(|(_exec, heartbeat)| {
+            .filter_map(|pair| {
+                let (_exec, heartbeat) = pair.pair();
                 (heartbeat.timestamp <= last_seen_threshold).then(|| heartbeat.clone())
             })
             .collect::<Vec<_>>();
@@ -523,15 +528,15 @@ impl ExecutorManager {
 /// and maintain an in-memory copy of the executor heartbeats.
 struct ExecutorHeartbeatListener {
     state: Arc<dyn StateBackendClient>,
-    executors_heartbeat: Arc<RwLock<HashMap<String, protobuf::ExecutorHeartbeat>>>,
-    dead_executors: Arc<RwLock<HashSet<String>>>,
+    executors_heartbeat: Arc<DashMap<String, protobuf::ExecutorHeartbeat>>,
+    dead_executors: Arc<DashSet<String>>,
 }
 
 impl ExecutorHeartbeatListener {
     pub fn new(
         state: Arc<dyn StateBackendClient>,
-        executors_heartbeat: Arc<RwLock<HashMap<String, protobuf::ExecutorHeartbeat>>>,
-        dead_executors: Arc<RwLock<HashSet<String>>>,
+        executors_heartbeat: Arc<DashMap<String, protobuf::ExecutorHeartbeat>>,
+        dead_executors: Arc<DashSet<String>>,
     ) -> Self {
         Self {
             state,
@@ -556,14 +561,13 @@ impl ExecutorHeartbeatListener {
                         decode_protobuf::<protobuf::ExecutorHeartbeat>(&value)
                     {
                         let executor_id = data.executor_id.clone();
-                        let mut heartbeats = heartbeats.write();
                         // Remove dead executors
                         if let Some(ExecutorStatus {
                             status: Some(executor_status::Status::Dead(_)),
                         }) = data.status
                         {
                             heartbeats.remove(&executor_id);
-                            dead_executors.write().insert(executor_id);
+                            dead_executors.insert(executor_id);
                         } else {
                             heartbeats.insert(executor_id, data);
                         }

--- a/ballista/rust/scheduler/src/state/mod.rs
+++ b/ballista/rust/scheduler/src/state/mod.rs
@@ -280,6 +280,19 @@ pub async fn with_lock<Out, F: Future<Output = Out>>(lock: Box<dyn Lock>, op: F)
 
     result
 }
+/// It takes multiple locks and reverse the order for releasing them to prevent a race condition.
+pub async fn with_locks<Out, F: Future<Output = Out>>(
+    locks: Vec<Box<dyn Lock>>,
+    op: F,
+) -> Out {
+    let mut locks = locks;
+    let result = op.await;
+    locks.reverse();
+    for mut lock in locks {
+        lock.unlock().await;
+    }
+    result
+}
 
 #[cfg(test)]
 mod test {

--- a/ballista/rust/scheduler/src/state/task_manager.rs
+++ b/ballista/rust/scheduler/src/state/task_manager.rs
@@ -322,7 +322,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
     ) -> Result<Vec<RunningTaskInfo>> {
         let locks = self
             .state
-            .locks(vec![
+            .acquire_locks(vec![
                 (Keyspace::ActiveJobs, job_id),
                 (Keyspace::FailedJobs, job_id),
             ])
@@ -355,7 +355,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
         debug!("Moving job {} from Active or Queue to Failed", job_id);
         let locks = self
             .state
-            .locks(vec![
+            .acquire_locks(vec![
                 (Keyspace::ActiveJobs, job_id),
                 (Keyspace::FailedJobs, job_id),
             ])

--- a/ballista/rust/scheduler/src/state/task_manager.rs
+++ b/ballista/rust/scheduler/src/state/task_manager.rs
@@ -17,7 +17,7 @@
 
 use crate::scheduler_server::event::QueryStageSchedulerEvent;
 use crate::scheduler_server::SessionBuilder;
-use crate::state::backend::{Keyspace, Lock, Operation, StateBackendClient};
+use crate::state::backend::{Keyspace, Operation, StateBackendClient};
 use crate::state::execution_graph::{
     ExecutionGraph, ExecutionStage, RunningTaskInfo, TaskDescription,
 };
@@ -447,13 +447,14 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
         let lock = self.state.lock(Keyspace::ActiveJobs, "").await?;
         with_lock(lock, async {
             // Transactional update graphs
-            let txn_ops: Vec<(Operation, Keyspace, String, Option<Vec<u8>>)> = updated_graphs
-                .into_iter()
-                .map(|(job_id, graph)| {
-                    let value = self.encode_execution_graph(graph)?;
-                    Ok((Operation::Put, Keyspace::ActiveJobs, job_id, Some(value)))
-                })
-                .collect::<Result<Vec<_>>>()?;
+            let txn_ops: Vec<(Operation, Keyspace, String, Option<Vec<u8>>)> =
+                updated_graphs
+                    .into_iter()
+                    .map(|(job_id, graph)| {
+                        let value = self.encode_execution_graph(graph)?;
+                        Ok((Operation::Put, Keyspace::ActiveJobs, job_id, Some(value)))
+                    })
+                    .collect::<Result<Vec<_>>>()?;
             self.state.apply_txn(txn_ops).await?;
             Ok(running_tasks_to_cancel)
         })

--- a/ballista/rust/scheduler/src/state/task_manager.rs
+++ b/ballista/rust/scheduler/src/state/task_manager.rs
@@ -17,10 +17,10 @@
 
 use crate::scheduler_server::event::QueryStageSchedulerEvent;
 use crate::scheduler_server::SessionBuilder;
-use crate::state::backend::{Keyspace, Lock, StateBackendClient};
+use crate::state::backend::{Keyspace, Operation, StateBackendClient};
 use crate::state::execution_graph::{ExecutionGraph, ExecutionStage, Task};
 use crate::state::executor_manager::{ExecutorManager, ExecutorReservation};
-use crate::state::{decode_protobuf, encode_protobuf, with_lock};
+use crate::state::{decode_protobuf, encode_protobuf, with_lock, with_locks};
 use ballista_core::config::BallistaConfig;
 #[cfg(not(test))]
 use ballista_core::error::BallistaError;
@@ -34,6 +34,7 @@ use ballista_core::serde::protobuf::{
 use ballista_core::serde::scheduler::to_proto::hash_partitioning_to_proto;
 use ballista_core::serde::scheduler::ExecutorMetadata;
 use ballista_core::serde::{AsExecutionPlan, BallistaCodec};
+use dashmap::DashMap;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::prelude::SessionContext;
 use datafusion_proto::logical_plan::AsLogicalPlan;
@@ -46,8 +47,8 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 use tonic::transport::Channel;
 
-type ExecutorClients = Arc<RwLock<HashMap<String, ExecutorGrpcClient<Channel>>>>;
-type ExecutionGraphCache = Arc<RwLock<HashMap<String, Arc<RwLock<ExecutionGraph>>>>>;
+type ExecutorClients = Arc<DashMap<String, ExecutorGrpcClient<Channel>>>;
+type ExecutionGraphCache = Arc<DashMap<String, Arc<RwLock<ExecutionGraph>>>>;
 
 #[derive(Clone)]
 pub struct TaskManager<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> {
@@ -74,7 +75,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
             session_builder,
             codec,
             scheduler_id,
-            active_job_cache: Arc::new(RwLock::new(HashMap::new())),
+            active_job_cache: Arc::new(DashMap::new()),
         }
     }
 
@@ -99,9 +100,8 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
             .await?;
 
         graph.revive();
-
-        let mut active_graph_cache = self.active_job_cache.write().await;
-        active_graph_cache.insert(job_id.to_owned(), Arc::new(RwLock::new(graph)));
+        self.active_job_cache
+            .insert(job_id.to_owned(), Arc::new(RwLock::new(graph)));
 
         Ok(())
     }
@@ -244,8 +244,8 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
         let mut assignments: Vec<(String, Task)> = vec![];
         let mut pending_tasks = 0usize;
         let mut assign_tasks = 0usize;
-        let job_cache = self.active_job_cache.read().await;
-        for (_job_id, graph) in job_cache.iter() {
+        for pairs in self.active_job_cache.iter() {
+            let (_job_id, graph) = pairs.pair();
             let mut graph = graph.write().await;
             for reservation in free_reservations.iter().skip(assign_tasks) {
                 if let Some(task) = graph.pop_next_task(&reservation.executor_id)? {
@@ -311,8 +311,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
             job_id
         );
 
-        self.fail_job_inner(lock, job_id, "Cancelled".to_owned())
-            .await?;
+        with_lock(lock, self.fail_job_inner(job_id, "Cancelled".to_owned())).await?;
 
         let mut tasks: HashMap<&str, Vec<protobuf::PartitionId>> = Default::default();
 
@@ -352,63 +351,96 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
 
     /// Mark a job as failed. This will create a key under the FailedJobs keyspace
     /// and remove the job from ActiveJobs or QueuedJobs
-    /// TODO this should be atomic
     pub async fn fail_job(&self, job_id: &str, error_message: String) -> Result<()> {
         debug!("Moving job {} from Active or Queue to Failed", job_id);
-        let lock = self.state.lock(Keyspace::ActiveJobs, "").await?;
-        self.fail_job_inner(lock, job_id, error_message).await
+        let locks = self
+            .state
+            .locks(vec![
+                (Keyspace::ActiveJobs, job_id),
+                (Keyspace::FailedJobs, job_id),
+            ])
+            .await?;
+        with_locks(locks, self.fail_job_inner(job_id, error_message)).await
     }
 
-    async fn fail_job_inner(
-        &self,
-        lock: Box<dyn Lock>,
-        job_id: &str,
-        error_message: String,
-    ) -> Result<()> {
-        with_lock(lock, self.state.delete(Keyspace::ActiveJobs, job_id)).await?;
+    async fn fail_job_inner(&self, job_id: &str, error_message: String) -> Result<()> {
+        let txn_operations =
+            |value: Vec<u8>| -> Vec<(Operation, Keyspace, String, Option<Vec<u8>>)> {
+                vec![
+                    (
+                        Operation::Delete,
+                        Keyspace::ActiveJobs,
+                        job_id.to_string(),
+                        None,
+                    ),
+                    (
+                        Operation::Put,
+                        Keyspace::FailedJobs,
+                        job_id.to_string(),
+                        Some(value),
+                    ),
+                ]
+            };
 
-        let value = if let Some(graph) = self.get_active_execution_graph(job_id).await {
+        if let Some(graph) = self.get_active_execution_graph(job_id).await {
             let mut graph = graph.write().await;
+            let previous_status = graph.status();
             graph.fail_job(error_message);
-            let graph = graph.clone();
-
-            self.encode_execution_graph(graph)?
+            let value = self.encode_execution_graph(graph.clone())?;
+            let txn_ops = txn_operations(value);
+            let result = self.state.apply_txn(txn_ops).await;
+            if result.is_err() {
+                // Rollback
+                graph.update_status(previous_status);
+                warn!("Rollback Execution Graph state change since it did not persisted due to a possible connection error.")
+            };
+            result
         } else {
             warn!("Fail to find job {} in the cache", job_id);
-
             let status = JobStatus {
                 status: Some(job_status::Status::Failed(FailedJob {
                     error: error_message.clone(),
                 })),
             };
-            encode_protobuf(&status)?
-        };
-
-        self.state
-            .put(Keyspace::FailedJobs, job_id.to_owned(), value)
-            .await?;
-
-        Ok(())
+            let value = encode_protobuf(&status)?;
+            let txn_ops = txn_operations(value);
+            self.state.apply_txn(txn_ops).await
+        }
     }
 
     /// Mark a job as failed. This will create a key under the FailedJobs keyspace
     /// and remove the job from ActiveJobs or QueuedJobs
-    /// TODO this should be atomic
     pub async fn fail_running_job(&self, job_id: &str) -> Result<()> {
         if let Some(graph) = self.get_active_execution_graph(job_id).await {
             let graph = graph.read().await.clone();
             let value = self.encode_execution_graph(graph)?;
-
             debug!("Moving job {} from Active to Failed", job_id);
-            let lock = self.state.lock(Keyspace::ActiveJobs, "").await?;
-            with_lock(lock, self.state.delete(Keyspace::ActiveJobs, job_id)).await?;
-            self.state
-                .put(Keyspace::FailedJobs, job_id.to_owned(), value)
+            let locks = self
+                .state
+                .locks(vec![(Keyspace::ActiveJobs, ""), (Keyspace::FailedJobs, "")])
                 .await?;
+            let _r: Result<()> = with_locks(locks, async {
+                let txn_ops = vec![
+                    (
+                        Operation::Delete,
+                        Keyspace::ActiveJobs,
+                        job_id.to_string(),
+                        None,
+                    ),
+                    (
+                        Operation::Put,
+                        Keyspace::FailedJobs,
+                        job_id.to_string(),
+                        Some(value),
+                    ),
+                ];
+                self.state.apply_txn(txn_ops).await?;
+                Ok(())
+            })
+            .await;
         } else {
             warn!("Fail to find job {} in the cache", job_id);
-        }
-
+        };
         Ok(())
     }
 
@@ -431,10 +463,10 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
 
     pub async fn executor_lost(&self, executor_id: &str) -> Result<()> {
         // Collect graphs we update so we can update them in storage
-        let mut updated_graphs: HashMap<String, ExecutionGraph> = HashMap::new();
+        let updated_graphs: DashMap<String, ExecutionGraph> = DashMap::new();
         {
-            let job_cache = self.active_job_cache.read().await;
-            for (job_id, graph) in job_cache.iter() {
+            for pairs in self.active_job_cache.iter() {
+                let (job_id, graph) = pairs.pair();
                 let mut graph = graph.write().await;
                 let reset = graph.reset_stages(executor_id)?;
                 if !reset.is_empty() {
@@ -446,14 +478,15 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
         let lock = self.state.lock(Keyspace::ActiveJobs, "").await?;
         with_lock(lock, async {
             // Transactional update graphs
-            let txn_ops: Vec<(Keyspace, String, Vec<u8>)> = updated_graphs
-                .into_iter()
-                .map(|(job_id, graph)| {
-                    let value = self.encode_execution_graph(graph)?;
-                    Ok((Keyspace::ActiveJobs, job_id, value))
-                })
-                .collect::<Result<Vec<_>>>()?;
-            self.state.put_txn(txn_ops).await?;
+            let txn_ops: Vec<(Operation, Keyspace, String, Option<Vec<u8>>)> =
+                updated_graphs
+                    .into_iter()
+                    .map(|(job_id, graph)| {
+                        let value = self.encode_execution_graph(graph)?;
+                        Ok((Operation::Put, Keyspace::ActiveJobs, job_id, Some(value)))
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+            self.state.apply_txn(txn_ops).await?;
             Ok(())
         })
         .await
@@ -538,8 +571,7 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
         &self,
         job_id: &str,
     ) -> Option<Arc<RwLock<ExecutionGraph>>> {
-        let active_graph_cache = self.active_job_cache.read().await;
-        active_graph_cache.get(job_id).cloned()
+        self.active_job_cache.get(job_id).map(|value| value.clone())
     }
 
     /// Get the `ExecutionGraph` for the given job ID. This will search fist in the `ActiveJobs`

--- a/ballista/rust/scheduler/src/state/task_manager.rs
+++ b/ballista/rust/scheduler/src/state/task_manager.rs
@@ -364,23 +364,16 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
     }
 
     async fn fail_job_state(&self, job_id: &str, failure_reason: String) -> Result<()> {
-        let txn_operations =
-            |value: Vec<u8>| -> Vec<(Operation, Keyspace, String, Option<Vec<u8>>)> {
-                vec![
-                    (
-                        Operation::Delete,
-                        Keyspace::ActiveJobs,
-                        job_id.to_string(),
-                        None,
-                    ),
-                    (
-                        Operation::Put,
-                        Keyspace::FailedJobs,
-                        job_id.to_string(),
-                        Some(value),
-                    ),
-                ]
-            };
+        let txn_operations = |value: Vec<u8>| -> Vec<(Operation, Keyspace, String)> {
+            vec![
+                (Operation::Delete, Keyspace::ActiveJobs, job_id.to_string()),
+                (
+                    Operation::Put(value),
+                    Keyspace::FailedJobs,
+                    job_id.to_string(),
+                ),
+            ]
+        };
 
         let _res = if let Some(graph) = self.get_active_execution_graph(job_id).await {
             let mut graph = graph.write().await;
@@ -447,14 +440,13 @@ impl<T: 'static + AsLogicalPlan, U: 'static + AsExecutionPlan> TaskManager<T, U>
         let lock = self.state.lock(Keyspace::ActiveJobs, "").await?;
         with_lock(lock, async {
             // Transactional update graphs
-            let txn_ops: Vec<(Operation, Keyspace, String, Option<Vec<u8>>)> =
-                updated_graphs
-                    .into_iter()
-                    .map(|(job_id, graph)| {
-                        let value = self.encode_execution_graph(graph)?;
-                        Ok((Operation::Put, Keyspace::ActiveJobs, job_id, Some(value)))
-                    })
-                    .collect::<Result<Vec<_>>>()?;
+            let txn_ops: Vec<(Operation, Keyspace, String)> = updated_graphs
+                .into_iter()
+                .map(|(job_id, graph)| {
+                    let value = self.encode_execution_graph(graph)?;
+                    Ok((Operation::Put(value), Keyspace::ActiveJobs, job_id))
+                })
+                .collect::<Result<Vec<_>>>()?;
             self.state.apply_txn(txn_ops).await?;
             Ok(running_tasks_to_cancel)
         })


### PR DESCRIPTION
# Which issue does this PR close?

Closes [101](https://github.com/apache/arrow-ballista/issues/101) and address multiple TODOs inside the codebase.

 # Rationale for this change
If a large number of states undergo updates, using `RwLock` for the scheduler's in-memory states at the global level will reduce the overall performance. Additionally, some state updates are not atomic and were listed as TODOs. The modifications in this PR makes concurrency more efficient during heavily loaded in-memory updates and more reliable during state persistence.

# What changes are included in this PR?
- Changed `RwLock<HashMap<K, V>>` into a `DashMap`. The [dashmap](https://docs.rs/dashmap) crate provides an implementation of a more sophisticated, high-performance concurrent hash map. For reference, DashMap stats are

  | Stars      | Forks      | Used By | Contributors | License     |
  |------------|------------|---------|--------------|-------------|
  | 1.8k stars | 104  forks | 42.8k   | 34           | MIT license |

- Now performing atomic transactions on `TaskManager` and `ExecuterManager`, resolving `TODO`s.
  - Change in `trait StateBackendClient`, converted method `put_txn` to a more general `apply_txn`.
  - Rollback if the state persisting is not successful.

# Are there any user-facing changes?
No
